### PR TITLE
Add migration sequence to accomodate ->constrained() migration

### DIFF
--- a/resources/stubs/Model.php
+++ b/resources/stubs/Model.php
@@ -13,6 +13,8 @@ class DummyModelClass extends Model
 
     protected $guarded = [];
 
+    public    $migration_sequence = 1;
+
     public function migration(Blueprint $table)
     {
         $table->id();

--- a/resources/stubs/UserModel.php
+++ b/resources/stubs/UserModel.php
@@ -18,6 +18,7 @@ class DummyModelClass extends Authenticatable
     protected $hashes = ['password'];
     protected $hidden = ['password', 'remember_token'];
     protected $casts = ['email_verified_at' => 'datetime'];
+    public    $migration_sequence = 0;
 
     public function migration(Blueprint $table)
     {


### PR DESCRIPTION
Hello @bastinald, 

Thanks a lot for this awesome package.
I'm Vincent from Indonesia, I recently explored your laravel-livewire-ui package.
However I found a problem whenever I create migration for a table that has a foreign to other tables.  An error would occurred because the migration of related table run before the foreign table exist: 
```
SQLSTATE[HY000]: General error: 1215 Cannot add foreign key constraint (SQL: alter table `table_products` add constraint `table_products_category_id_foreign` foreign key (`category_id`) references `id` (`categories`))
```

I tried to make some modification by sorting the model files using defined $migration_sequence variable. Using this variable, we can defined the migration running sequence. 

If you think this is a good solution, you can freely accept this PR. 

Thanks.